### PR TITLE
Add health check endpoint test

### DIFF
--- a/backend/tests/test_healthz.py
+++ b/backend/tests/test_healthz.py
@@ -1,0 +1,16 @@
+import sys
+from pathlib import Path
+from fastapi.testclient import TestClient
+
+# Ensure the backend 'app' package is importable
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from app.main import app
+
+client = TestClient(app)
+
+
+def test_healthz():
+    response = client.get("/healthz")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}


### PR DESCRIPTION
## Summary
- add FastAPI unit test for `/healthz`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `cd backend && poetry run pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_b_688afbb813f0832691fd5db4ee42dd31